### PR TITLE
Linking everything internally to avoid linker errors

### DIFF
--- a/_._
+++ b/_._
@@ -3,6 +3,8 @@
 
 #include <iostream>
 
+namespace
+{
 // A simple stream.
 struct asstream {
   struct asstream_tag {};
@@ -24,5 +26,5 @@ std::istream& operator>>(asstream::asstream_tag&, T& o) {
   std::cin >> o;
   return std::cin;
 }
-
+} // namespace
 #endif


### PR DESCRIPTION
Including the header in multiple compilation units yields linker errors. C++03 compliant solution: link everything internally