### PR TITLE
Improve integration with IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(_._ INTERFACE)
 include(CTest)
 include(GNUInstallDirs)
 target_include_directories(_._ INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+add_custom_target(__.__ SOURCES _._)
 
 # Tests and examples
 if(ENABLE_TESTING)


### PR DESCRIPTION
Display the \_._ source file in targets view. Qt Creator example:
![before](https://user-images.githubusercontent.com/35731382/132073676-dbd0428a-5003-4988-b050-41a4e10bde2e.png) ![after](https://user-images.githubusercontent.com/35731382/132073655-2191c4f0-86bc-45c9-9974-e9d589ba4c91.png)



Why not INTERFACE_SOURCES? It is not a good enough solution because it will display the file under each dependent target instead of one place